### PR TITLE
Update the URLs and apkArtifacts  for Firefox Nightly and Beta

### DIFF
--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/FirefoxBeta.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/FirefoxBeta.kt
@@ -17,7 +17,7 @@ import de.marmaro.krt.ffupdater.settings.DeviceSettingsHelper
 import de.marmaro.krt.ffupdater.settings.NetworkSettingsHelper
 
 /**
- * https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v2.fenix.beta.latest
+ * https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v3.firefox-android.apks.fenix-beta.latest
  * https://www.apkmirror.com/apk/mozilla/firefox-beta/
  */
 class FirefoxBeta(
@@ -38,7 +38,7 @@ class FirefoxBeta(
     @Suppress("SpellCheckingInspection")
     override val signatureHash = "a78b62a5165b4494b2fead9e76a280d22d937fee6251aece599446b2ea319b04"
     override val projectPage =
-        "https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v2.fenix.beta.latest"
+        "https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v3.firefox-android.apks.fenix-beta.latest"
     override val displayCategory = DisplayCategory.FROM_MOZILLA
 
     @MainThread
@@ -57,8 +57,8 @@ class FirefoxBeta(
             else -> throw IllegalArgumentException("ABI is not supported")
         }
         val result = consumer.updateCheck(
-            task = "mobile.v2.fenix.beta.latest.$abiString",
-            apkArtifact = "public/build/$abiString/target.apk",
+            task = "mobile.v3.firefox-android.apks.fenix-beta.latest.$abiString",
+            apkArtifact = "public/build/fenix/$abiString/target.apk",
             settings = networkSettings
         )
         val version = result.version

--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/FirefoxNightly.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/FirefoxNightly.kt
@@ -24,7 +24,6 @@ import java.time.format.DateTimeFormatter
 
 /**
  * https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v3.firefox-android.apks.fenix-nightly.latest
- * https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v3.firefox-android.apks.fenix-nightly.latest
  * https://www.apkmirror.com/apk/mozilla/firefox-fenix/
  */
 class FirefoxNightly(

--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/FirefoxNightly.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/FirefoxNightly.kt
@@ -23,7 +23,8 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 /**
- * https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v2.fenix.nightly.latest
+ * https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v3.firefox-android.apks.fenix-nightly.latest
+ * https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v3.firefox-android.apks.fenix-nightly.latest
  * https://www.apkmirror.com/apk/mozilla/firefox-fenix/
  */
 class FirefoxNightly(
@@ -45,7 +46,7 @@ class FirefoxNightly(
     override val signatureHash = "5004779088e7f988d5bc5cc5f8798febf4f8cd084a1b2a46efd4c8ee4aeaf211"
     override val supportedAbis = ARM32_ARM64_X86_X64
     override val projectPage =
-        "https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v2.fenix.nightly.latest"
+        "https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v3.firefox-android.apks.fenix-nightly.latest"
     override val displayCategory = DisplayCategory.FROM_MOZILLA
 
     @MainThread
@@ -64,8 +65,8 @@ class FirefoxNightly(
             else -> throw IllegalArgumentException("ABI is not supported")
         }
         val result = consumer.updateCheck(
-            task = "mobile.v2.fenix.nightly.latest.$abiString",
-            apkArtifact = "public/build/$abiString/target.apk",
+            task = "mobile.v3.firefox-android.apks.fenix-nightly.latest.$abiString",
+            apkArtifact = "public/build/fenix/$abiString/target.apk",
             settings = networkSettings
         )
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")


### PR DESCRIPTION
It appear that Firefox moved Beta and Nightly apks to new resource paths. This PR updates `FirefoxNightly` and `FirefoxBeta` to point to the new locations.