### PR TITLE
Inform users that Kiwi Browser is not truly open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Browser which are better than Google Chrome:
 - [Cromite](https://github.com/uazo/cromite)
 - [Chromium](https://www.chromium.org/chromium-projects/)
 - [DuckDuckGo Browser](https://github.com/duckduckgo/Android)
-- [Kiwi Browser Next](https://github.com/kiwibrowser/src.next)
+- [Kiwi Browser Next](https://github.com/kiwibrowser/src.next) ([Incomplete Source Code](https://github.com/kiwibrowser/src.next/issues/1028))
 - [Vivaldi](https://vivaldi.com/download/) ([Incomplete Source Code](https://vivaldi.com/source/))
 - [Thorium](https://github.com/Alex313031/Thorium-Android)
 


### PR DESCRIPTION
I noticed that Kiwi did not have the (Incomplete Source Code) warning like Vivaldi does. Considering Kiwi is listed here along with other, actually open source browsers, I feel like not adding a similar warning would be misleading.

Really not trying to start drama here, but I was the one that originally asked the dev this question, and objectively speaking, the answer I received was, paraphrasing "Kiwi is not open source at this time, the source may be updated some time next year."

The source of this information is in the link I've added to the Readme in this PR.