### PR TITLE
Add support for requesting update ownership on Android 14+

### DIFF
--- a/ffupdater/src/main/AndroidManifest.xml
+++ b/ffupdater/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.ENFORCE_UPDATE_OWNERSHIP" />
 
     <!-- Shizuku needs API 23, but I still want to use API 21-->
     <uses-sdk tools:overrideLibrary="rikka.shizuku.api, rikka.shizuku.provider, rikka.shizuku.shared, rikka.shizuku.aidl" />

--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/installer/impl/SessionInstaller.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/installer/impl/SessionInstaller.kt
@@ -142,7 +142,11 @@ open class SessionInstaller(private val foreground: Boolean) : AppInstaller {
         if (DeviceSdkTester.supportsAndroid7Nougat24()) params.setOriginatingUid(android.os.Process.myUid())
         if (DeviceSdkTester.supportsAndroid8Oreo26()) params.setInstallReason(PackageManager.INSTALL_REASON_USER)
         if (DeviceSdkTester.supportsAndroid12S31()) params.setRequireUserAction(USER_ACTION_NOT_REQUIRED)
-        if (DeviceSdkTester.supportsAndroid14U34()) params.setDontKillApp(true)
+        if (DeviceSdkTester.supportsAndroid14U34()) {
+            params.setDontKillApp(true)
+            // This only takes effect for initial installs, but is a no-op for updates.
+            params.setRequestUpdateOwnership(true)
+        }
         allowAppReplacement(params)
         return params
     }


### PR DESCRIPTION
If update ownership is requested during the initial install (it is a no-op for updates), then other app stores are not allowed to update the app without explicit user action. This stops Google Play from updating Firefox because the versionCode of the APKs published there are always higher.

~The feature is disabled by default and is hidden if the device is running older versions of Android or if the installer method is not the session installer.~ EDIT: No longer optional

---

Screenshot of Google Play's page for Firefox when this option is used: [Screenshot_20240525-113105](https://github.com/Tobi823/ffupdater/assets/646253/7412e72c-5be4-4132-9b49-713500ddb5d2). Firefox also no longer shows up in Google Play's pending updates list.
