### PR TITLE
Use primaryColor for status bar color

### DIFF
--- a/ffupdater/src/main/res/values/styles.xml
+++ b/ffupdater/src/main/res/values/styles.xml
@@ -3,6 +3,7 @@
 
     <style name="main_activity__theme" parent="@style/Theme.Material3.DayNight.NoActionBar">
         <item name="colorSurface">@color/colorPrimary</item>
+        <item name="android:statusBarColor">@color/colorPrimary</item>
     </style>
 
     <style name="crash_report__theme" parent="Theme.AppCompat.DayNight.DarkActionBar">


### PR DESCRIPTION
Fixes in my opinion an annoying visual issue:

![statusbar-old](https://github.com/Tobi823/ffupdater/assets/22685799/1ff71f08-397e-456a-b21e-db74af6c5e34)

The status bar color does not match the app bar color. While I believe this is not intentional, in the case that it is it should at least be corrected to a color with better contrast with the status bar text.

This is now the result after the fix (also works in light mode):

![Screenshot from 2024-05-27 19-40-38](https://github.com/Tobi823/ffupdater/assets/22685799/95ef662a-68ec-434c-ac3c-d462e23cb06d)

There seems to be the same problem in the settings page but I did not fix it.

