### PR TITLE
Update asset regex for K-9 Mail updates

### DIFF
--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/K9Mail.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/K9Mail.kt
@@ -39,7 +39,7 @@ object K9Mail : AppBase() {
         val result = GithubConsumer.findLatestRelease(
             repository = GithubConsumer.GithubRepo("thunderbird", "thunderbird-android", 0),
             isValidRelease = { true },
-            isSuitableAsset = { it.name.matches("k9-([0-9.]+).apk".toRegex()) },
+            isSuitableAsset = { it.name.matches("k9mail-([0-9.]+).apk".toRegex()) },
             requireReleaseDescription = false,
         )
         return LatestVersion(


### PR DESCRIPTION
Fixes #643

We're using k9mail-NNN.apk going forward. I don't think we need to match old asset names, do we?