### PR TITLE
Support new K9Mail tag

### DIFF
--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/K9Mail.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/K9Mail.kt
@@ -42,9 +42,10 @@ object K9Mail : AppBase() {
             isSuitableAsset = { it.name.matches("k9mail-([0-9.]+).apk".toRegex()) },
             requireReleaseDescription = false,
         )
+        val version = result.tagName.replace("K9MAIL_", "").replace("_", ".")
         return LatestVersion(
             downloadUrl = result.url,
-            version = Version(result.tagName),
+            version = Version(version),
             publishDate = result.releaseDate,
             exactFileSizeBytesOfDownload = result.fileSizeBytes,
             fileHash = null,


### PR DESCRIPTION
Thunderbird team changed K9's tag. FFUpdater updates K9 on every check now.

Old one
[6.804](https://github.com/thunderbird/thunderbird-android/releases/tag/6.804)
New one
[K9MAIL_8_1](https://github.com/thunderbird/thunderbird-android/releases/tag/K9MAIL_8_1)