### PR TITLE
Add Mull to list of EOL browsers (o7)

### DIFF
--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/MullFromRepo.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/MullFromRepo.kt
@@ -7,8 +7,7 @@ import androidx.annotation.MainThread
 import androidx.preference.PreferenceManager
 import de.marmaro.krt.ffupdater.R
 import de.marmaro.krt.ffupdater.app.App
-import de.marmaro.krt.ffupdater.app.entity.DisplayCategory.BASED_ON_FIREFOX
-import de.marmaro.krt.ffupdater.app.entity.DisplayCategory.GOOD_PRIVACY_BROWSER
+import de.marmaro.krt.ffupdater.app.entity.DisplayCategory.EOL
 import de.marmaro.krt.ffupdater.app.entity.LatestVersion
 import de.marmaro.krt.ffupdater.device.DeviceAbiExtractor
 import de.marmaro.krt.ffupdater.network.exceptions.NetworkException
@@ -32,7 +31,7 @@ object MullFromRepo : AppBase() {
     @Suppress("SpellCheckingInspection")
     override val signatureHash = "260e0a49678c78b70c02d6537add3b6dc0a17171bbde8ce75fd4026a8a3e18d2"
     override val projectPage = "https://divestos.org/fdroid/official/"
-    override val displayCategory = listOf(BASED_ON_FIREFOX, GOOD_PRIVACY_BROWSER)
+    override val displayCategory = listOf(EOL)
     override val hostnameForInternetCheck = "https://divestos.org"
 
     @MainThread


### PR DESCRIPTION
Updates the list of installable apps to put Mull in the End-of-Life category.

#665 

*Note:* I haven't tested ffupdater running, just that it builds successfully.