### PR TITLE
Compare full date and time of FF Nightly releases

### DIFF
--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/entity/Version.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/entity/Version.kt
@@ -3,14 +3,14 @@ package de.marmaro.krt.ffupdater.app.entity
 import android.os.Parcelable
 import androidx.annotation.Keep
 import kotlinx.parcelize.Parcelize
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 /**
- * buildDate is sometimes necessary to distinguish two different versions with the same version text (see Firefox Nightly).
+ * buildDateTime is sometimes necessary to distinguish two different versions with the same version text (see Firefox Nightly).
  * Normally this value could be set.
  */
 @Parcelize
 @Keep
-data class Version(val versionText: String, val buildDate: LocalDate?) : Parcelable {
+data class Version(val versionText: String, val buildDateTime: LocalDateTime?) : Parcelable {
     constructor(versionText: String) : this(versionText, null)
 }

--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/FirefoxNightly.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/FirefoxNightly.kt
@@ -17,7 +17,7 @@ import de.marmaro.krt.ffupdater.network.website.MozillaArchiveConsumer
 import de.marmaro.krt.ffupdater.settings.DeviceSettingsHelper
 import okio.IOException
 import org.json.JSONException
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 /**
  * https://archive.mozilla.org/pub/fenix/nightly/2024/05/2024-05-20-21-46-33-fenix-128.0a1-android-arm64-v8a/
@@ -53,11 +53,11 @@ object FirefoxNightly : AppBase() {
         val page = findPageUrl(abi)
         val version = Regex("""fenix-(\d+\.\d+a\d+)-android""").find(page)!!.groups[1]!!.value
         val downloadUrl = "${page}fenix-$version.multi.android-$abi.apk"
-        val buildDate = extractBuildDateFromUrl(page).getOrThrow()
+        val buildDateTime = extractBuildDateTimeFromUrl(page).getOrThrow()
         val dateTime = MozillaArchiveConsumer.findDateTimeFromPage(page)
         return LatestVersion(
             downloadUrl = downloadUrl,
-            version = Version(version, buildDate),
+            version = Version(version, buildDateTime),
             publishDate = dateTime.toString(),
             exactFileSizeBytesOfDownload = null,
             fileHash = null,
@@ -78,9 +78,9 @@ object FirefoxNightly : AppBase() {
         return page5
     }
 
-    private fun extractBuildDateFromUrl(url: String): Result<LocalDate> {
-        val matchResult = Regex("""/(\d{4})-(\d{2})-(\d{2})-\d{2}-\d{2}-\d{2}-fenix-""").find(url)
-        if (matchResult == null || matchResult.groups.size != 4) {
+    private fun extractBuildDateTimeFromUrl(url: String): Result<LocalDateTime> {
+        val matchResult = Regex("""/(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-fenix-""").find(url)
+        if (matchResult == null || matchResult.groups.size != 7) {
             return Result.failure(RuntimeException("Can't find build date"))
         }
         val groups = matchResult.groups
@@ -90,19 +90,25 @@ object FirefoxNightly : AppBase() {
             ?: return Result.failure(RuntimeException("Can't extract month from version."))
         val day = groups[3]?.value?.toIntOrNull()
             ?: return Result.failure(RuntimeException("Can't extract day from version."))
+        val hour = groups[4]?.value?.toIntOrNull()
+            ?: return Result.failure(RuntimeException("Can't extract hour from version."))
+        val minute = groups[5]?.value?.toIntOrNull()
+            ?: return Result.failure(RuntimeException("Can't extract minute from version."))
+        val second = groups[6]?.value?.toIntOrNull()
+            ?: return Result.failure(RuntimeException("Can't extract second from version."))
 
-        val date = LocalDate.of(year, month, day)
-        return Result.success(date)
+        val dateTime = LocalDateTime.of(year, month, day, hour, minute, second)
+        return Result.success(dateTime)
     }
 
 
-    private fun extractBuildDateFromInstalledApp(packageManager: PackageManager): Result<LocalDate> {
+    private fun extractBuildDateFromInstalledApp(packageManager: PackageManager): Result<LocalDateTime> {
         val version = extractInternalVersionStringFromInstalledApp(packageManager).onFailure {
             return Result.failure(it)
         }.getOrThrow()
 
-        val matchResult = Regex("""\d+\.\d+\.(\d{4})(\d{2})(\d{2})\.\d+""").find(version)
-        if (matchResult == null || matchResult.groups.size != 4) {
+        val matchResult = Regex("""\d+\.\d+\.(\d{4})(\d{2})(\d{2})\.(\d{1,2})(\d{2})(\d{2})""").find(version)
+        if (matchResult == null || matchResult.groups.size != 7) {
             return Result.failure(RuntimeException("Version schema does not match."))
         }
 
@@ -113,9 +119,15 @@ object FirefoxNightly : AppBase() {
             ?: return Result.failure(RuntimeException("Can't extract month from version."))
         val day = groups[3]?.value?.toIntOrNull()
             ?: return Result.failure(RuntimeException("Can't extract day from version."))
+        val hour = groups[4]?.value?.toIntOrNull()
+            ?: return Result.failure(RuntimeException("Can't extract hour from version."))
+        val minute = groups[5]?.value?.toIntOrNull()
+            ?: return Result.failure(RuntimeException("Can't extract minute from version."))
+        val second = groups[6]?.value?.toIntOrNull()
+            ?: return Result.failure(RuntimeException("Can't extract second from version."))
 
-        val date = LocalDate.of(year, month, day)
-        return Result.success(date)
+        val dateTime = LocalDateTime.of(year, month, day, hour, minute, second)
+        return Result.success(dateTime)
     }
 
     private fun extractInternalVersionStringFromInstalledApp(packageManager: PackageManager): Result<String> {

--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/base/ApkDownloader.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/base/ApkDownloader.kt
@@ -86,8 +86,8 @@ interface ApkDownloader : AppAttributes {
 
     private fun convertToBase64(latestVersion: LatestVersion): String {
         val versionStr = latestVersion.version.versionText
-        val dateStr = latestVersion.version.buildDate?.format(DateTimeFormatter.BASIC_ISO_DATE) ?: ""
-        val input = "$versionStr $dateStr".toByteArray(Charset.forName("UTF8"))
+        val dateTimeStr = latestVersion.version.buildDateTime?.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) ?: ""
+        val input = "$versionStr $dateTimeStr".toByteArray(Charset.forName("UTF8"))
         return encodeToString(input, URL_SAFE)
     }
 

--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/base/InstalledAppStatusFetcher.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/base/InstalledAppStatusFetcher.kt
@@ -20,8 +20,8 @@ interface InstalledAppStatusFetcher : InstalledVersionFetcher, LatestVersionFetc
 
     suspend fun isInstalledAppOutdated(context: Context, available: LatestVersion): Boolean {
         val installedVersion = getInstalledVersion(context.packageManager) ?: return true
-        if (installedVersion.versionText == available.version.versionText && installedVersion.buildDate != null && available.version.buildDate != null) {
-            return available.version.buildDate.isAfter(installedVersion.buildDate)
+        if (installedVersion.versionText == available.version.versionText && installedVersion.buildDateTime != null && available.version.buildDateTime != null) {
+            return available.version.buildDateTime.isAfter(installedVersion.buildDateTime)
         }
         return VersionCompareHelper.isAvailableVersionHigher(
             installedVersion.versionText, available.version.versionText

--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/base/VersionDisplay.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/base/VersionDisplay.kt
@@ -11,15 +11,15 @@ interface VersionDisplay : InstalledVersionFetcher {
     @AnyThread
     suspend fun getDisplayInstalledVersion(context: Context): String {
         val version = getInstalledVersion(context.packageManager) ?: return ""
-        val buildDate = version.buildDate?.let { " [$it]" } ?: ""
-        return context.getString(R.string.installed_version, version.versionText + buildDate)
+        val buildDateTime = version.buildDateTime?.let { " [$it]" } ?: ""
+        return context.getString(R.string.installed_version, version.versionText + buildDateTime)
     }
 
     @AnyThread
     fun getDisplayAvailableVersion(context: Context, availableVersionResult: LatestVersion): String {
         val version = availableVersionResult.version
-        val buildDate = version.buildDate?.let { " [$it]" } ?: ""
-        return context.getString(R.string.available_version, version.versionText + buildDate)
+        val buildDateTime = version.buildDateTime?.let { " [$it]" } ?: ""
+        return context.getString(R.string.available_version, version.versionText + buildDateTime)
     }
 
 }


### PR DESCRIPTION
Firefox Nightly is released twice a day, so a comparison of version, date and time is required to differentiate between releases.