### PR TITLE
Fix toolbar menu button colour

### DIFF
--- a/ffupdater/src/main/res/layout/activity_main.xml
+++ b/ffupdater/src/main/res/layout/activity_main.xml
@@ -20,7 +20,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
-            style="@style/main_activity__main_title"
+            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
             app:menu="@menu/menu"
             app:title="@string/app_name"/>
 

--- a/ffupdater/src/main/res/values/styles.xml
+++ b/ffupdater/src/main/res/values/styles.xml
@@ -12,10 +12,6 @@
         <item name="colorAccent">@color/crash_report__color_accent</item>
     </style>
 
-    <style name="main_activity__main_title">
-        <item name="titleTextColor">@android:color/white</item>
-    </style>
-
     <style name="install_activity__default_text">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
The dark theme forces white text and button colour. I'm not sure how does it work, because I tried multiple `styles.xml` changes (to `main_activity__main_title`) including primary text, secondary text, tertiary text, button, control and foreground colours and none of them worked. Creating a separate style with `android:tint` pointed to by `actionOverflowButtonStyle` as suggested in some places also did not work.

Since the the (forced dark) theme applies also to the pop-up appearance, `app:popupTheme` must be set to `DayNight` to respect device's light/dark mode setting.

Fixes #753