### PR TITLE
Fix sorting by version of Tor Browser Alpha

### DIFF
--- a/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/TorBrowserAlpha.kt
+++ b/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/impl/TorBrowserAlpha.kt
@@ -68,7 +68,7 @@ object TorBrowserAlpha : AppBase() {
         val versions = Regex(pattern).findAll(content) // find all potential version values from content
             .filter { it.groups[1]?.value == it.groups[4]?.value } // check if version value is valid
             .mapNotNull { it.groups[1]?.value } // use only non null version values
-            .sortedByDescending { Version(it) } // sort and use only the highest version value
+            .sortedByDescending { Version(it.replace("a", "-alpha")) } // sort and use only the highest version value
             .toList()
 
         check(versions.isNotEmpty()) { "Found no versions" }


### PR DESCRIPTION
The "a" suffix is not SemVer and is ignored by the Version Compare library. When directory listing has multiple versions that differ only by the suffix (e.g. 16.0a6 and 16.0a7), the latest version may not be detected.

This Version Compare behaviour was noticed by you (@Tobi823): https://github.com/G00fY2/version-compare/issues/12

Using `VersionCompareHelper.convertToVersion()` instead of replacing `a` with `-alpha` also should work, but it's `private`, so I decided not to use it.

https://github.com/Tobi823/ffupdater/blob/9830452fe1cb3b77b28175833c68118a63d5ca69/ffupdater/src/main/java/de/marmaro/krt/ffupdater/app/VersionCompareHelper.kt#L31-L34